### PR TITLE
Fix Python 3 support and add short options support

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -14,13 +14,13 @@ def main():
     parser = argparse.ArgumentParser(
         prog="docker-hub", description=DESCRIPTION, epilog=EPILOG,
              formatter_class=argparse.RawTextHelpFormatter)
-    username_arg = parser.add_argument('--username', help=HELPMSGS['username'])
-    org_name_arg = parser.add_argument('--orgname', help=HELPMSGS['orgname'])
-    repo_name_arg = parser.add_argument('--reponame',
+    username_arg = parser.add_argument('-u', '--username', help=HELPMSGS['username'])
+    org_name_arg = parser.add_argument('-o', '--orgname', help=HELPMSGS['orgname'])
+    repo_name_arg = parser.add_argument('-r', '--reponame',
                                         help=HELPMSGS['reponame'])
-    page = parser.add_argument('--page', nargs='?', default=1,
+    page = parser.add_argument('-p', '--page', nargs='?', default=1,
                                help=HELPMSGS['page'])
-    display_format = parser.add_argument('--format', help=HELPMSGS['format'],
+    display_format = parser.add_argument('-f', '--format', help=HELPMSGS['format'],
                                          choices=VALID_DISPLAY_FORMATS)
 
     required_args = {

--- a/src/commands/users.py
+++ b/src/commands/users.py
@@ -16,6 +16,6 @@ def run(docker_hub_client, args):
                 resp['content'][key] = formatted_date
             rows.append([key, resp['content'][key]])
         heading = "User profile of %s" % (args.username)
-        print_result(args.format, rows, heading=heading)
+        print_result(args.format, rows, heading=heading, count=1)
     else:
         print('Error fetching profile for: ' + args.username)

--- a/src/commands/version.py
+++ b/src/commands/version.py
@@ -4,4 +4,4 @@ from .. import __version__
 
 def run(docker_hub_client, args):
     """ The command to list repos of given org from docker hub """
-    print 'docker-hub ' + __version__
+    print('docker-hub ' + __version__)

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -45,7 +45,7 @@ def print_result(format, rows=[], header=[], count=0, page=1, heading=False):
 
     if format == 'table':
         if count == 0:
-            print 'No results found for your query.'
+            print('No results found for your query.')
         else:
             total_pages = int(((count - 1)/PER_PAGE) + 1)
             if heading:


### PR DESCRIPTION
* Fix Python 3
* Fix users
* Add short options

```
$ docker-hub -h
usage: docker-hub [-h] [-u USERNAME] [-o ORGNAME] [-r REPONAME] [-p [PAGE]]
                  [-f {table,json}]
                  {repos,tags,builds,users,queue,version}

Access docker hub from your terminal

positional arguments:
  {repos,tags,builds,users,queue,version}
                        The api method to query {repos, tags, builds, users, queue, version}

optional arguments:
  -h, --help            show this help message and exit
  -u USERNAME, --username USERNAME
                        The Docker Hub username
  -o ORGNAME, --orgname ORGNAME
                        Your orgname
  -r REPONAME, --reponame REPONAME
                        The name of repository
  -p [PAGE], --page [PAGE]
                        The page of result to fetch
  -f {table,json}, --format {table,json}
                        You can dispaly results in table, json formats

Docker Hub in your terminal
```