### PR TITLE
[cli] Produce valid JSON when `-f json` flag passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,57 +13,58 @@ You should have pip installed in your system.
 ```sh
 pip install docker-hub
 ```
-python 3 users can do
+Python 3 users can do:
 ```sh
 pip3 install docker-hub
 ```
 
 ## Usage
 ##### 1. Authenticate with Docker Hub
-If you are already loggedin using `docker login` command, then the token in docker engine config will be used. Otherwise you can choose to proceed without authenticating which will query docker hub without token and list only public resources. To authenticate for viewing private resources do `docker-hub login` command; this will save auth token in docker-hub's config file so that you don't need to do login everytime.
+If you are already logged in using `docker login` command, then the token in Docker engine config will be used. Otherwise you can choose to proceed without authenticating which will query docker hub without token and list only public resources. To authenticate for viewing private resources do `docker-hub login` command; this will save auth token in `docker-hub`'s config file so that you don't need to login every time.
 
-If you want to authenticate for only current command(to not presist auth tokens in config) make use of the following env variables:
-  * DOCKER_HUB_USERNAME - Your Docker Hub username
-  * DOCKER_HUB_PASSWORD - Your Docker Hub password
+If you want to authenticate for the only current command (to not persist auth tokens in config), make use of the following env variables:
+
+  * `DOCKER_HUB_USERNAME` - Your Docker Hub username
+  * `DOCKER_HUB_PASSWORD` - Your Docker Hub password
 
 Pass the mentioned envs with your command and docker-hub will try to do authentication without prompting for credentials.
 
-eg:
+e.g.:
 ```sh
 DOCKER_HUB_USERNAME=hello DOCKER_HUB_PASSWORD=world docker-hub repos --orgname docker
 ```
 
 ##### 2. Querying an organization for repositories
 To query repositories in an organization use `repos` argument. The organization to query can be passed as `--orgname` or `-o` parameter.
-eg: Get repos in organization named "docker"
+e.g.: Get repos in organization named "docker"
 ```sh
 docker-hub repos --orgname docker
 ```
 
 ##### 3. Querying the tags of a repository
 To query tags of a repository use `tags` argument. The organization of repository can be passed as `--orgname` or `-o` parameter. The repository to query can be passed as `--reponame` or `-r` parameter.
-eg: Get tags of repository "ucp" in organization named "docker"
+e.g.: Get tags of repository "ucp" in organization named "docker"
 ```sh
 docker-hub tags --orgname docker --reponame ucp
 ```
 
 ##### 4. Querying a user profile
 To query a user profile use `users` argument. The username to query can be passed as `--username` or `-u` parameter.
-eg: Get profile of user named "docker"
+e.g.: Get profile of user named "docker"
 ```sh
 docker-hub users --username docker
 ```
 
 ##### 5. Querying the auto-builds of a repository
 To query auto-builds of a repository use `builds` argument. The organization of repository can be passed as `--orgname` or `-o` parameter. The repository to query can be passed as `--reponame` or `-r` parameter.
-eg: Get build of repository "ucp" in organization named "docker"
+e.g.: Get build of repository "ucp" in organization named "docker"
 ```sh
 docker-hub builds --orgname docker --reponame ucp
 ```
 
 ##### 6. Querying an organization for auto-build queue
 To query the auto-build repositories with pending builds use the `queue` argument. The organization to query can be passed as `--orgname` or `-o` parameter.
-eg: Get the building queue for organization named "docker"
+e.g.: Get the building queue for organization named "docker"
 ```sh
 docker-hub queue --orgname docker
 ```
@@ -71,7 +72,7 @@ docker-hub queue --orgname docker
 ##### Notes:
 * Only 15 results will be displayed at once. You can fetch remaining pages by passing `--page` or `-p` parameter.
 
-  eg: Get 3rd page
+  e.g.: Get 3rd page
   ```sh
   docker-hub repos --orgname docker --page 3
   ```
@@ -81,7 +82,7 @@ docker-hub queue --orgname docker
 
   `--format` or `-f` parameter can be used to specify the format in which result must be displayed.
 
-  eg:
+  e.g.:
   * Display in json format
   ```sh
   docker-hub repos --orgname docker --format json

--- a/src/cli.py
+++ b/src/cli.py
@@ -53,8 +53,6 @@ def main():
                                        docker_hub_password_env, False):
             print('Invalid credentials. Failed logging in to Docker Hub.')
             sys.exit(1)
-        else:
-            print('Logged in to Docker Hub.\n')
     # Check if an auth token is present
     login_token_present = docker_client.get_auth_token() or \
         docker_hub_client.get_token()

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -1,8 +1,9 @@
 # -*- encoding: utf-8 -*-
-import sys
 import argparse
 import getpass
+import json
 import math
+import sys
 from tabulate import tabulate
 from ..consts import PER_PAGE
 
@@ -55,11 +56,7 @@ def print_result(format, rows=[], header=[], count=0, page=1, heading=False):
                              (count, page, total_pages))
             print_table(header, rows)
     else:
-        json_result = []
-        for row in rows:
-            json_dict = {}
-            json_dict = dict(zip(header, row))
-            json_result.append(json_dict)
+        json_result = json.dumps([dict(zip(header, row)) for row in rows])
         print(json_result)
 
 


### PR DESCRIPTION
### What does this PR do?
Amends the `--format json` flag to print valid JSON, which can be piped into other commands for further processing.

### What's the context?
Hiya!
Long time user, first time contributor. I noticed that the "JSON" output format isn't actually valid JSON, but rather Python's standard serialized dict=>string format (using e.g., single quoted strings as keys, which are forbidden in the JSON spec); this makes **combining** the `docker-hub` command — something I find myself increasingly doing — not particularly [Unix friendly](http://harmful.cat-v.org/cat-v/unix_prog_design.pdf).

In particular, outputting _only_ valid JSON (no headers, etc.) to stdout ensures that the command can be easily piped into other tools, notably [`jq`](https://stedolan.github.io/jq/), allowing all sorts of fun constructions. I'll just give a couple examples —

Let's say I just want to see how many docker pulls my top N repos have received — I can simply run:
```sh
λ docker-hub repos -o jessestuart -f json | jq '.[] | ."Pull count"' | sum
110171
```

Or, say I want to easily query repo's tags and slicing / dicing / filtering based on arbitrary fields:
```sh
λ docker-hub tags -o jessestuart -r minio -f json | jq '.[] | .Name, ."Size", ."Last updated"' | xargs -L3 echo | sort -k2,3h | column -t
RELEASE.2018-06-09T03-43-35Z        20.49  MB  2018-06-22  00:29
RELEASE.2018-06-22T23-48-46Z        20.5   MB  2018-06-29  00:27
RELEASE.2018-06-22T23-48-46Z-amd64  20.5   MB  2018-06-29  00:17
RELEASE.2018-06-29T02-11-29Z        20.5   MB  2018-07-05  00:38
RELEASE.2018-06-29T02-11-29Z-amd64  20.5   MB  2018-07-05  00:28
latest                              20.5   MB  2018-07-05  00:38
latest-amd64                        20.5   MB  2018-07-05  00:28
RELEASE.2018-06-09T03-43-35Z-arm64  27.06  MB  2018-06-22  00:24
RELEASE.2018-06-22T23-48-46Z-arm64  27.07  MB  2018-06-29  00:20
RELEASE.2018-06-29T02-11-29Z-arm64  27.08  MB  2018-07-05  00:27
latest-arm64                        27.08  MB  2018-07-05  00:27
RELEASE.2018-06-09T03-43-35Z-arm    27.63  MB  2018-06-22  00:24
RELEASE.2018-06-22T23-48-46Z-arm    27.65  MB  2018-06-29  00:19
RELEASE.2018-06-29T02-11-29Z-arm    27.65  MB  2018-07-05  00:26
latest-arm                          27.65  MB  2018-07-05  00:26
```

Last one — and a pattern I use all the time — is to look up the N most recent published tags for an image:
```sh
λ docker-hub tags -o library -r consul -f json | jq -r '.[range(0,5)].Name'
latest
1.2.0
1.1.0
1.0.7
1.0.6
```

### Other things to note?

In the interest of keeping the command's stdout clean & consistent to enable reuse (see the paper referenced above), I also removed the println stating that the DH login was successful. Feel free to object to this — those who prefer the unix-y style can easily `grep -v` that out — but I didn't feel like it added much value, since (personally) as a user, I assume that a command I execute multiple times will transparently handle auth after initial setup, and after that should only be alerted if authentication fails.